### PR TITLE
Add MD4 implementation.

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -11,6 +11,7 @@ With 5MB message (10 iterations):
 
 | Algorithms    | `hashlib`      | `PointyCastle`                | `crypto`                     | `hash`                       |
 | ------------- | -------------- | ----------------------------- | ---------------------------- | ---------------------------- |
+| MD4           | TODO           | TODO                          | ➖                           | ➖                           |
 | MD5           | **170.44MB/s** | 82.22MB/s <br> `107% slower`  | 136.08MB/s <br> `25% slower` | 75.89MB/s <br> `125% slower` |
 | HMAC(MD5)     | **162.81MB/s** | ➖                            | 134.81MB/s <br> `21% slower` | 77.15MB/s <br> `111% slower` |
 | SHA-1         | **143.81MB/s** | 53.44MB/s <br> `169% slower`  | 102.45MB/s <br> `40% slower` | 43.15MB/s <br> `233% slower` |
@@ -38,6 +39,7 @@ With 1KB message (5000 iterations):
 
 | Algorithms    | `hashlib`      | `PointyCastle`                | `crypto`                     | `hash`                       |
 | ------------- | -------------- | ----------------------------- | ---------------------------- | ---------------------------- |
+| MD4           | TODO           | TODO                          | ➖                           | ➖                           |
 | MD5           | **162.06MB/s** | 80.19MB/s <br> `102% slower`  | 127.99MB/s <br> `27% slower` | 97.19MB/s <br> `67% slower`  |
 | HMAC(MD5)     | **129.87MB/s** | ➖                            | 105.50MB/s <br> `23% slower` | 74.01MB/s <br> `75% slower`  |
 | SHA-1         | **134.21MB/s** | 50.28MB/s <br> `167% slower`  | 96.20MB/s <br> `40% slower`  | 47.46MB/s <br> `183% slower` |
@@ -65,6 +67,7 @@ With 10B message (100000 iterations):
 
 | Algorithms    | `hashlib`     | `PointyCastle`                 | `crypto`                    | `hash`                      |
 | ------------- | ------------- | ------------------------------ | --------------------------- | --------------------------- |
+| MD4           | TODO          | TODO                           | ➖                          | ➖                          |
 | MD5           | **28.40MB/s** | 14.16MB/s <br> `101% slower`   | 14.65MB/s <br> `94% slower` | 8.04MB/s <br> `253% slower` |
 | HMAC(MD5)     | **5.26MB/s**  | ➖                             | 4.46MB/s <br> `18% slower`  | 2.10MB/s <br> `150% slower` |
 | SHA-1         | **16.24MB/s** | 7.46MB/s <br> `118% slower`    | 11.47MB/s <br> `42% slower` | 5.05MB/s <br> `222% slower` |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There is only 1 dependency used by this package:
 
 | Algorithm   | Available methods                                                  |         Source          |
 | ----------- | ------------------------------------------------------------------ | :---------------------: |
+| MD4         | `md4`                                                              |        RFC-1320         |
 | MD5         | `md5`                                                              |        RFC-1321         |
 | SHA-1       | `sha1`                                                             |        RFC-3174         |
 | SHA-2       | `sha224`, `sha256`, `sha384`, `sha512`, `sha512t224`, `sha512t256` |        RFC-6234         |
@@ -114,6 +115,7 @@ void main() {
   print('[XXH64] => ${xxh64sum(text)}');
   print('[XXH3] => ${xxh3sum(text)}');
   print('[XXH128] => ${xxh128sum(text)}');
+  print('[MD4] => ${md4.string(text)}');
   print('[MD5] => ${md5.string(text)}');
   print('[SHA-1] => ${sha1.string(text)}');
   print('[SHA-224] => ${sha224.string(text)}');
@@ -185,6 +187,7 @@ With 5MB message (10 iterations):
 
 | Algorithms    | `hashlib`      | `PointyCastle`                | `crypto`                     | `hash`                       |
 | ------------- | -------------- | ----------------------------- | ---------------------------- | ---------------------------- |
+| MD4           | TODO           | TODO                          | ➖                           | ➖                           |
 | MD5           | **170.53MB/s** | 81.35MB/s <br> `110% slower`  | 136.30MB/s <br> `25% slower` | 76.73MB/s <br> `122% slower` |
 | HMAC(MD5)     | **159.58MB/s** | ➖                            | 136.15MB/s <br> `17% slower` | 76.89MB/s <br> `108% slower` |
 | SHA-1         | **142.59MB/s** | 53.02MB/s <br> `169% slower`  | 102.50MB/s <br> `39% slower` | 43.61MB/s <br> `227% slower` |
@@ -212,6 +215,7 @@ With 1KB message (5000 iterations):
 
 | Algorithms    | `hashlib`      | `PointyCastle`                | `crypto`                     | `hash`                       |
 | ------------- | -------------- | ----------------------------- | ---------------------------- | ---------------------------- |
+| MD4           | TODO           | TODO                          | ➖                           | ➖                           |
 | MD5           | **161.58MB/s** | 80.23MB/s <br> `101% slower`  | 127.70MB/s <br> `27% slower` | 98.07MB/s <br> `65% slower`  |
 | HMAC(MD5)     | **129.45MB/s** | ➖                            | 106.28MB/s <br> `22% slower` | 72.41MB/s <br> `79% slower`  |
 | SHA-1         | **131.47MB/s** | 50.05MB/s <br> `163% slower`  | 96.13MB/s <br> `37% slower`  | 47.31MB/s <br> `178% slower` |
@@ -239,6 +243,7 @@ With 10B message (100000 iterations):
 
 | Algorithms    | `hashlib`      | `PointyCastle`                 | `crypto`                    | `hash`                      |
 | ------------- | -------------- | ------------------------------ | --------------------------- | --------------------------- |
+| MD4           | TODO           | TODO                          | ➖                           | ➖                           |
 | MD5           | **28.34MB/s**  | 14.11MB/s <br> `101% slower`   | 14.84MB/s <br> `91% slower` | 8.08MB/s <br> `251% slower` |
 | HMAC(MD5)     | **5.23MB/s**   | ➖                             | 4.47MB/s <br> `17% slower`  | 2.12MB/s <br> `146% slower` |
 | SHA-1         | **16.28MB/s**  | 7.77MB/s <br> `110% slower`    | 11.52MB/s <br> `41% slower` | 5.03MB/s <br> `224% slower` |

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -13,6 +13,7 @@ import 'blake2s.dart' as blake2s;
 import 'hmac_md5.dart' as md5_hmac;
 import 'hmac_sha1.dart' as sha1_hmac;
 import 'hmac_sha256.dart' as sha256_hmac;
+import 'md4.dart' as md4;
 import 'md5.dart' as md5;
 import 'poly1305.dart' as poly1305;
 import 'ripemd128.dart' as ripemd128;
@@ -51,6 +52,10 @@ void measureHashFunctions() {
     var iter = condition[1];
 
     var algorithms = {
+      "MD4": [
+        md4.HashlibBenchmark(size, iter),
+        md4.PointyCastleBenchmark(size, iter),
+      ],
       "MD5": [
         md5.HashlibBenchmark(size, iter),
         md5.CryptoBenchmark(size, iter),

--- a/benchmark/md4.dart
+++ b/benchmark/md4.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2023, Sudipto Chandra
+// All rights reserved. Check LICENSE file for details.
+
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:hashlib/hashlib.dart' as hashlib;
+import 'package:pointycastle/digests/md4.dart' as pc;
+
+import 'base.dart';
+
+Random random = Random();
+
+class HashlibBenchmark extends Benchmark {
+  HashlibBenchmark(int size, int iter) : super('hashlib', size, iter);
+
+  @override
+  void run() {
+    hashlib.md4.convert(input).bytes;
+  }
+}
+
+class PointyCastleBenchmark extends Benchmark {
+  Uint8List _input = Uint8List(0);
+  PointyCastleBenchmark(int size, int iter) : super('PointyCastle', size, iter);
+
+  @override
+  void setup() {
+    super.setup();
+    _input = Uint8List.fromList(input);
+  }
+
+  @override
+  void run() {
+    final d = pc.MD4Digest();
+    d.process(_input);
+  }
+}
+
+void main() {
+  print('--------- MD4 ----------');
+  final conditions = [
+    [5 << 20, 10],
+    [1 << 10, 5000],
+    [10, 100000],
+  ];
+  for (var condition in conditions) {
+    int size = condition[0];
+    int iter = condition[1];
+    print('---- size: ${formatSize(size)} | iterations: $iter ----');
+    HashlibBenchmark(size, iter).showDiff([
+      PointyCastleBenchmark(size, iter),
+    ]);
+    print('');
+  }
+}

--- a/example/hashlib_example.dart
+++ b/example/hashlib_example.dart
@@ -23,6 +23,7 @@ void main() {
   print('[XXH64] => ${xxh64sum(text)}');
   print('[XXH3] => ${xxh3sum(text)}');
   print('[XXH128] => ${xxh128sum(text)}');
+  print('[MD4] => ${md4.string(text)}');
   print('[MD5] => ${md5.string(text)}');
   print('[SHA-1] => ${sha1.string(text)}');
   print('[SHA-224] => ${sha224.string(text)}');

--- a/lib/src/algorithms/md4.dart
+++ b/lib/src/algorithms/md4.dart
@@ -94,10 +94,7 @@ class MD4Hash extends BlockHashSink {
 
     for (int i = 32; i < 48; i++) {
       e = b ^ c ^ d;
-      f = ((i & 1) << 3) |
-          (((i >> 1) & 1) << 2) |
-          (((i >> 2) & 1) << 1) |
-          ((i >> 3) & 1);
+      f = ((i & 1) << 3) | ((i & 2) << 1) | ((i >> 1) & 2) | ((i >> 3) & 1);
       t = d;
       d = c;
       c = b;

--- a/lib/src/algorithms/md4.dart
+++ b/lib/src/algorithms/md4.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2023, Sudipto Chandra
+// All rights reserved. Check LICENSE file for details.
+
+import 'dart:typed_data';
+
+import 'package:hashlib/src/core/block_hash.dart';
+
+const int _mask32 = 0xFFFFFFFF;
+
+const _iv = <int>[
+  0x67452301, // a
+  0xEFCDAB89, // b
+  0x98BADCFE, // c
+  0x10325476, // d
+];
+
+/// Shift constants
+const _rc = <int>[
+  03, 07, 11, 19, 03, 07, 11, 19, 03, 07, 11, 19, 03, 07, 11, 19, //
+  03, 05, 09, 13, 03, 05, 09, 13, 03, 05, 09, 13, 03, 05, 09, 13, //
+  03, 09, 11, 15, 03, 09, 11, 15, 03, 09, 11, 15, 03, 09, 11, 15,
+];
+
+/// This implementation is derived from the RSA Data Security, Inc.
+/// [MD4 Message-Digest Algorithm][rfc1320].
+///
+/// [rfc1320]: https://www.ietf.org/rfc/rfc1320.html
+class MD4Hash extends BlockHashSink {
+  final Uint32List state;
+
+  @override
+  final int hashLength;
+
+  MD4Hash()
+      : state = Uint32List.fromList(_iv),
+        hashLength = 128 >>> 3,
+        super(512 >>> 3);
+
+  @override
+  void reset() {
+    super.reset();
+    state.setAll(0, _iv);
+  }
+
+  @override
+  void $process(List<int> chunk, int start, int end) {
+    messageLength += end - start;
+    for (; start < end; start++, pos++) {
+      if (pos == blockLength) {
+        $update();
+        pos = 0;
+      }
+      buffer[pos] = chunk[start];
+    }
+    if (pos == blockLength) {
+      $update(buffer);
+      pos = 0;
+    }
+  }
+
+  @override
+  void $update([List<int>? block, int offset = 0, bool last = false]) {
+    int a, b, c, d, e, f, g, h, t;
+    var x = sbuffer;
+
+    a = state[0];
+    b = state[1];
+    c = state[2];
+    d = state[3];
+
+    for (int i = 0; i < 16; i++) {
+      e = (b & c) | ((~b & _mask32) & d);
+      f = i;
+      t = d;
+      d = c;
+      c = b;
+      g = (a + e + x[f]) & _mask32;
+      h = _rc[i];
+      b = ((g << h) & _mask32) | (g >>> (32 - h));
+      a = t;
+    }
+
+    for (int i = 16; i < 32; i++) {
+      e = (b & c) | (b & d) | (c & d);
+      f = ((i >> 2) & 3) + ((i & 3) << 2);
+      t = d;
+      d = c;
+      c = b;
+      g = (a + e + 0x5a827999 + x[f]) & _mask32;
+      h = _rc[i];
+      b = ((g << h) & _mask32) | (g >>> (32 - h));
+      a = t;
+    }
+
+    for (int i = 32; i < 48; i++) {
+      e = b ^ c ^ d;
+      f = ((i & 1) << 3) |
+          (((i >> 1) & 1) << 2) |
+          (((i >> 2) & 1) << 1) |
+          ((i >> 3) & 1);
+      t = d;
+      d = c;
+      c = b;
+      g = (a + e + 0x6ed9eba1 + x[f]) & _mask32;
+      h = _rc[i];
+      b = ((g << h) & _mask32) | (g >>> (32 - h));
+      a = t;
+    }
+
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+  }
+
+  @override
+  Uint8List $finalize() {
+    // Adding the signature byte
+    buffer[pos++] = 0x80;
+
+    // If no more space left in buffer for the message length
+    if (pos > 56) {
+      for (; pos < 64; pos++) {
+        buffer[pos] = 0;
+      }
+      $update();
+      pos = 0;
+    }
+
+    // Fill remaining buffer to put the message length at the end
+    for (; pos < 56; pos++) {
+      buffer[pos] = 0;
+    }
+
+    // Append original message length in bits to message
+    bdata.setUint32(56, messageLengthInBits, Endian.little);
+    bdata.setUint32(60, messageLengthInBits >>> 32, Endian.little);
+
+    // Update with the final block
+    $update();
+
+    // Convert the state to 8-bit byte array
+    return state.buffer.asUint8List().sublist(0, hashLength);
+  }
+}

--- a/lib/src/hashlib_base.dart
+++ b/lib/src/hashlib_base.dart
@@ -18,6 +18,7 @@ export 'keccak224.dart';
 export 'keccak256.dart';
 export 'keccak384.dart';
 export 'keccak512.dart';
+export 'md4.dart';
 export 'md5.dart';
 export 'otpauth.dart';
 export 'pbkdf2.dart';

--- a/lib/src/md4.dart
+++ b/lib/src/md4.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, Sudipto Chandra
+// All rights reserved. Check LICENSE file for details.
+
+import 'dart:convert';
+
+import 'package:hashlib/src/algorithms/md4.dart';
+import 'package:hashlib/src/core/block_hash.dart';
+import 'package:hashlib/src/core/hash_digest.dart';
+
+/// MD4 can be used as a checksum to verify data integrity against unintentional
+/// corruption. Although it was widely used as a cryptographic hash function
+/// once, it has been found to suffer from extensive vulnerabilities.
+///
+/// **WARNING: It should not be used for cryptographic purposes.**
+const BlockHashBase md4 = _MD4();
+
+class _MD4 extends BlockHashBase {
+  const _MD4();
+
+  @override
+  final String name = 'MD4';
+
+  @override
+  MD4Hash createSink() => MD4Hash();
+}
+
+/// Generates a MD4 checksum in hexadecimal
+///
+/// Parameters:
+/// - [input] is the string to hash
+/// - The [encoding] is the encoding to use. Default is `input.codeUnits`
+/// - [uppercase] defines if the hexadecimal output should be in uppercase
+String md4sum(
+  String input, [
+  Encoding? encoding,
+  bool uppercase = false,
+]) {
+  return md4.string(input, encoding).hex(uppercase);
+}
+
+/// Extension to [String] to generate [md4] hash
+extension Md4StringExtension on String {
+  /// Generates a MD4 digest of this string
+  ///
+  /// Parameters:
+  /// - If no [encoding] is defined, the `codeUnits` is used to get the bytes.
+  HashDigest md4digest([Encoding? encoding]) {
+    return md4.string(this, encoding);
+  }
+}

--- a/lib/src/registry.dart
+++ b/lib/src/registry.dart
@@ -15,6 +15,7 @@ import 'keccak224.dart';
 import 'keccak256.dart';
 import 'keccak384.dart';
 import 'keccak512.dart';
+import 'md4.dart';
 import 'md5.dart';
 import 'sha1.dart';
 import 'sha224.dart';
@@ -64,6 +65,7 @@ void _buildRegistry() {
     _normalize(keccak256.name): keccak256,
     _normalize(keccak384.name): keccak384,
     _normalize(keccak512.name): keccak512,
+    _normalize(md4.name): md4,
     _normalize(md5.name): md5,
     _normalize(sha1.name): sha1,
     _normalize(sha224.name): sha224,

--- a/test/md4_test.dart
+++ b/test/md4_test.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2023, Sudipto Chandra
+// All rights reserved. Check LICENSE file for details.
+
+import 'dart:async';
+import 'dart:math';
+
+import 'package:hashlib/hashlib.dart';
+import 'package:test/test.dart';
+
+final tests = {
+  "": "31d6cfe0d16ae931b73c59d7e0c089c0",
+  "a": "bde52cb31de33e46245e05fbdbd6fb24",
+  "abc": "a448017aaf21d8525fc10ae87aa6729d",
+  "message digest": "d9130a8164549fe818874806e1c7014b",
+  "abcdefghijklmnopqrstuvwxyz": "d79e1c308aa5bbcdeea8ed63df412da9",
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789":
+      "043f8582f241db351ce627e153e7f0e4",
+  "12345678901234567890123456789012345678901234567890123456789012345678901234567890":
+      "e33b4ddc9c38f2199c3e7b164fcc0536",
+  "123": "c58cda49f00748a3bc0fcfa511d516cb",
+  "test": "db346d691d7acc4dc2625db19f9e3f52",
+  'message': "ffa70bbb57bda34ec842cac3d9a099aa",
+  "Hello World": "77a781b995cf1cfaf39d9e2f5910c2cf",
+  List.filled(512, "a").join(): "71ad0ebe8db92f0deca36c233e1ac4cb",
+  List.filled(128, "a").join(): "cb4a20a561558e29460190c91dced59f",
+  List.filled(513, "a").join(): "e5f5b4253616aeb972b6f823a2519911",
+  List.filled(511, "a").join(): "1c2912a2a50886af88bbf6b374593d6c",
+  List.filled(1000000, "a").join(): "bbce80cc6bb65e5c6745e30d4eeca9a4",
+};
+
+void main() {
+  group('MD4 test', () {
+    test('with empty string', () {
+      expect(md4sum(""), tests[""]);
+    });
+
+    test('with single letter', () {
+      expect("a".md4digest().hex(), tests["a"]);
+    });
+
+    test('with few letters', () {
+      expect(md4sum("abc"), tests["abc"]);
+    });
+
+    test('with longest string', () {
+      var last = tests.entries.last;
+      expect(md4sum(last.key), last.value);
+    });
+
+    test('with special case', () {
+      var key =
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+      expect(md4sum(key), tests[key]);
+    });
+
+    test('with string of length 511', () {
+      var key = tests.keys.firstWhere((x) => x.length == 511);
+      var value = tests[key]!;
+      expect(md4sum(key), value);
+    });
+
+    test('with known cases', () {
+      tests.forEach((key, value) {
+        expect(md4sum(key), value);
+      });
+    });
+
+    test('with stream', () async {
+      for (final entry in tests.entries) {
+        final stream = Stream.fromIterable(
+                List.generate(1 + (entry.key.length >>> 3), (i) => i << 3))
+            .map((e) => entry.key.substring(e, min(entry.key.length, e + 8)))
+            .map((s) => s.codeUnits);
+        final result = await md4.consume(stream);
+        expect(result.hex(), entry.value);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #20 if you are keen on adding MD4 support. Despite being obsolete, I think it is worthwhile since it reuses much of the MD5 implementation, and it is supported by pointycastle.

Benchmarks on AMD 5800X / 3200MHz RAM / Linux x64 as follows

```text
--------- MD4 ----------
---- size: 5MB | iterations: 10 ----
hashlib : 264.30MB/s [best]
PointyCastle : 137.14MB/s ~ 93% slower

---- size: 1KB | iterations: 5000 ----
hashlib : 245.74MB/s [best]
PointyCastle : 129.37MB/s ~ 90% slower

---- size: 10B | iterations: 100000 ----
hashlib : 33.94MB/s [best]
PointyCastle : 18.32MB/s ~ 85% slower
```

Benchmark results in `BENCHMARK.md` and `README.md` are left as **TODO** so you can put in your own benchmark numbers.