### PR TITLE
Secure random number generation.

### DIFF
--- a/lib/src/random/generator_js.dart
+++ b/lib/src/random/generator_js.dart
@@ -14,8 +14,8 @@ external JSObject require(String id);
 @JS()
 @staticInterop
 class NodeCrypto {
-  static void randomFillSync(JSArrayBuffer buf) =>
-      require('crypto').callMethod('randomFillSync'.toJS, buf);
+  static void randomFillSync(JSTypedArray buffer) =>
+      require('crypto').callMethod('randomFillSync'.toJS, buffer);
 }
 
 class NodeRandom implements Random {
@@ -44,7 +44,7 @@ class NodeRandom implements Random {
 
     int v = rejectionLimit;
     while (v >= rejectionLimit) {
-      NodeCrypto.randomFillSync(list.buffer.toJS);
+      NodeCrypto.randomFillSync(list.toJS);
       v = ByteData.sublistView(list).getUint32(0);
     }
     return v % max;

--- a/lib/src/random/generator_js.dart
+++ b/lib/src/random/generator_js.dart
@@ -6,6 +6,8 @@ import 'dart:js_interop';
 
 const int _mask32 = 0xFFFFFFFF;
 
+const bool isWASM = bool.fromEnvironment('dart.tool.dart2wasm');
+
 @JS()
 @staticInterop
 class Process {}
@@ -25,7 +27,7 @@ extension on Versions {
   external JSAny get node;
 }
 
-bool get _isNodeJS => (_process?.versions)?.node != null;
+bool get isNodeDart2JS => _process?.versions?.node != null && !isWASM;
 
 @JS()
 @staticInterop
@@ -62,7 +64,7 @@ class NodeRandom implements Random {
 }
 
 /// Returns a secure random generator in JS runtime
-Random secureRandom() => _isNodeJS ? NodeRandom() : Random.secure();
+Random secureRandom() => isNodeDart2JS ? NodeRandom() : Random.secure();
 
 /// Generates a random seed
 int $generateSeed() => secureRandom().nextInt(_mask32);

--- a/lib/src/random/generator_js.dart
+++ b/lib/src/random/generator_js.dart
@@ -7,15 +7,15 @@ import 'dart:js_interop';
 const int _mask32 = 0xFFFFFFFF;
 
 @JS()
-external JSObject require(String id);
-
-@JS()
 @staticInterop
 class Crypto {}
 
 extension on Crypto {
-  external int randomInt(int max);
+  external int randomInt(final int max);
 }
+
+@JS()
+external Crypto require(final String id);
 
 class NodeRandom implements Random {
   @override
@@ -29,12 +29,12 @@ class NodeRandom implements Random {
   }
 
   @override
-  int nextInt(int max) {
+  int nextInt(final int max) {
     if (max < 1 || max > _mask32 + 1) {
       throw RangeError.range(
           max, 1, _mask32 + 1, 'max', 'max must be <= (1 << 32)');
     }
-    return (require('crypto') as Crypto).randomInt(max);
+    return require('crypto').randomInt(max);
   }
 }
 

--- a/lib/src/random/generator_js.dart
+++ b/lib/src/random/generator_js.dart
@@ -1,18 +1,31 @@
 // Copyright (c) 2024, Sudipto Chandra
 // All rights reserved. Check LICENSE file for details.
 
-import 'dart:js_interop_unsafe';
 import 'dart:math' show Random;
 import 'dart:js_interop';
 
 const int _mask32 = 0xFFFFFFFF;
 
-@JS('process')
-external JSObject? get _process;
+@JS()
+@staticInterop
+class Process {}
 
-bool get _isNodeJS => ((_process?.getProperty('versions'.toJS) as JSObject?)
-        ?.getProperty('node'.toJS))
-    .isDefinedAndNotNull;
+@JS()
+@staticInterop
+class Versions {}
+
+@JS('process')
+external Process? get _process;
+
+extension on Process {
+  external Versions? get versions;
+}
+
+extension on Versions {
+  external JSAny get node;
+}
+
+bool get _isNodeJS => (_process?.versions)?.node != null;
 
 @JS()
 @staticInterop

--- a/lib/src/random/generator_js.dart
+++ b/lib/src/random/generator_js.dart
@@ -6,7 +6,7 @@ import 'dart:js_interop';
 
 const int _mask32 = 0xFFFFFFFF;
 
-const bool isWASM = bool.fromEnvironment('dart.tool.dart2wasm');
+const bool isDart2JS = bool.fromEnvironment('dart.tool.dart2js');
 
 @JS()
 @staticInterop
@@ -27,7 +27,7 @@ extension on Versions {
   external JSAny get node;
 }
 
-bool get isNodeDart2JS => _process?.versions?.node != null && !isWASM;
+bool get isNodeDart2JS => _process?.versions?.node != null && isDart2JS;
 
 @JS()
 @staticInterop

--- a/lib/src/random/generator_js.dart
+++ b/lib/src/random/generator_js.dart
@@ -1,10 +1,18 @@
 // Copyright (c) 2024, Sudipto Chandra
 // All rights reserved. Check LICENSE file for details.
 
+import 'dart:js_interop_unsafe';
 import 'dart:math' show Random;
 import 'dart:js_interop';
 
 const int _mask32 = 0xFFFFFFFF;
+
+@JS('process')
+external JSObject? get _process;
+
+bool get _isNodeJS => ((_process?.getProperty('versions'.toJS) as JSObject?)
+        ?.getProperty('node'.toJS))
+    .isDefinedAndNotNull;
 
 @JS()
 @staticInterop
@@ -17,17 +25,8 @@ extension on Crypto {
 @JS()
 external Crypto require(final String id);
 
+/// For Node.js environment + dart2js compiler
 class NodeRandom implements Random {
-  @override
-  bool nextBool() => nextInt(2) == 1;
-
-  @override
-  double nextDouble() {
-    final int a = nextInt(1 << 26); // 26 bits
-    final int b = nextInt(1 << 27); // 27 bits
-    return ((a << 27) + b) / (1 << 53); // 26 + 27 = 53 bits (JS limit)
-  }
-
   @override
   int nextInt(final int max) {
     if (max < 1 || max > _mask32 + 1) {
@@ -36,21 +35,21 @@ class NodeRandom implements Random {
     }
     return require('crypto').randomInt(max);
   }
+
+  @override
+  double nextDouble() {
+    final int first26Bits = nextInt(1 << 26);
+    final int next27Bits = nextInt(1 << 27);
+    final int random53Bits = (first26Bits << 27) + next27Bits; // JS int limit
+    return random53Bits / (1 << 53);
+  }
+
+  @override
+  bool nextBool() => nextInt(2) == 1;
 }
 
 /// Returns a secure random generator in JS runtime
-Random secureRandom() {
-  try {
-    return Random.secure();
-  } catch (e) {
-    // For Node.js with dart2js compiler, the following error is expected.
-    if (e.runtimeType.toString() == 'UnknownJsTypeError') {
-      // This error is internal to 'dart:_js_helper'.
-      return NodeRandom();
-    }
-    rethrow;
-  }
-}
+Random secureRandom() => _isNodeJS ? NodeRandom() : Random.secure();
 
 /// Generates a random seed
 int $generateSeed() => secureRandom().nextInt(_mask32);

--- a/lib/src/random/generator_vm.dart
+++ b/lib/src/random/generator_vm.dart
@@ -11,6 +11,4 @@ Random secureRandom() => Random.secure();
 
 /// Generates a random seed
 @pragma('vm:prefer-inline')
-int $generateSeed() =>
-    (DateTime.now().microsecondsSinceEpoch & _mask32) ^
-    Random.secure().nextInt(_mask32);
+int $generateSeed() => Random.secure().nextInt(_mask32);

--- a/lib/src/random/generators.dart
+++ b/lib/src/random/generators.dart
@@ -34,13 +34,13 @@ enum RNG {
       case RNG.keccak:
         return _keccakGenerateor(seed);
       case RNG.sha256:
-        return _hashGenerateor(SHA256Hash(), seed);
+        return _hashGenerator(SHA256Hash(), seed);
       case RNG.md5:
-        return _hashGenerateor(MD4Hash(), seed);
+        return _hashGenerator(MD4Hash(), seed);
       case RNG.xxh64:
-        return _hashGenerateor(XXHash64Sink(111), seed);
+        return _hashGenerator(XXHash64Sink(111), seed);
       case RNG.sm3:
-        return _hashGenerateor(SM3Hash(), seed);
+        return _hashGenerator(SM3Hash(), seed);
       case RNG.system:
         return _systemGenerator(seed);
       case RNG.secure:
@@ -115,7 +115,7 @@ NextIntFunction _keccakGenerateor([int? seed]) {
 }
 
 /// Returns a iterable of 32-bit integers generated from the [sink].
-NextIntFunction _hashGenerateor(
+NextIntFunction _hashGenerator(
   HashDigestSink sink, [
   int? seed,
 ]) {


### PR DESCRIPTION
## Summary

- Add a Node-compatible secure Random implementation that uses Node's `crypto.randomInt()`; all other JS platforms are compatible with the default `Random.secure()`.
- Avoid mixing predictable datetime output with CSPRNG output.

Tested with

```bash
dart test -p vm,chrome,node -c kernel,dart2js,dart2wasm test/random/random_test.dart
```

## Changes

- generator_vm.dart
  - Avoid mixing predictable datetime output with CSPRNG output.
- generator_js.dart
  - Avoid mixing predictable datetime output with CSPRNG output.
  - Added `NodeRandom` as an implementation of `Random` for NodeJS.
  - `nextInt(max)` draws 32-bit values from Node crypto, supports max ∈ [1, 2^32].
  - `secureRandom()` uses `Random.secure()` for web browsers, and `NodeRandom` for Node.js.
  - `$generateSeed()` delegates to `secureRandom()`.
- generators.dart
  - Fixed spelling of `_hashGenerator`

## Notes

- Consider adjusting $generateSeed() to request the full 2^32 range (_mask32 + 1) to cover the entire 32-bit space.