### PR TITLE
Optimize Argon2 on the Web/JS platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.3
+
+- Optimize Argon2 on the Web/JS platform by replacing `BigInt` arithmetic in the compression function with 32-bit integer math
+
 # 2.4.2
 
 - Bump `convertlib` to `^3.5.1`

--- a/lib/src/algorithms/argon2/argon2_32bit.dart
+++ b/lib/src/algorithms/argon2/argon2_32bit.dart
@@ -421,13 +421,36 @@ class Argon2Internal {
   }
 
   /// `v[x] += v[y] + 2 * ((v[x] & _mask32) * (v[y] & _mask32))`
+  ///
+  /// The 64-bit words are stored as (low, high) 32-bit pairs. To stay correct
+  /// on the web where integers are IEEE-754 doubles, the low-word product is
+  /// built from 16-bit limbs and every carry is propagated with `~/`/`%` by
+  /// `2^32`; all intermediate values remain below `2^53`, so no precision is
+  /// lost and no `BigInt` allocation is needed.
   static void _fBlaMka(Uint32List v, int x, int y) {
-    var t = (BigInt.from(v[x]) * BigInt.from(v[y])) << 1;
-    t += (BigInt.from(v[x + 1]) << 32) + BigInt.from(v[x]);
-    t += (BigInt.from(v[y + 1]) << 32) + BigInt.from(v[y]);
+    int xl = v[x], xh = v[x + 1];
+    int yl = v[y], yh = v[y + 1];
 
-    v[x] = t.toUnsigned(32).toInt();
-    v[x + 1] = (t >> 32).toUnsigned(32).toInt();
+    // Full 32x32 -> 64 product of the low words via 16-bit limbs.
+    int a0 = xl & _mask16, a1 = xl >>> 16;
+    int b0 = yl & _mask16, b1 = yl >>> 16;
+    int m0 = a0 * b0;
+    int m1 = a0 * b1 + a1 * b0;
+    int m2 = a1 * b1;
+    int lo = m0 + (m1 % 0x10000) * 0x10000;
+    int pLo = lo % 0x100000000;
+    int pHi = m2 + m1 ~/ 0x10000 + lo ~/ 0x100000000;
+
+    // Double the product: 2 * p (mod 2^64).
+    int dLo = pLo * 2;
+    int dHi = pHi * 2 + dLo ~/ 0x100000000;
+    dLo %= 0x100000000;
+
+    // v[x] = (xl,xh) + (yl,yh) + (dLo,dHi) (mod 2^64).
+    int sumLo = xl + yl + dLo;
+    int sumHi = xh + yh + dHi + sumLo ~/ 0x100000000;
+    v[x] = sumLo; // Uint32List store truncates to the low 32 bits
+    v[x + 1] = sumHi;
   }
 
   // v[k] = (v[i] << (64 - n)) | (v[i] >>> n)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hashlib
 description: Secure hash functions, checksum generators, and key derivation algorithms optimized for Dart.
 homepage: https://github.com/bitanon/hashlib
-version: 2.4.2
+version: 2.4.3
 
 environment:
   sdk: '>=2.19.0 <4.0.0'


### PR DESCRIPTION
## Summary

Optimizes the Web/JS (Node/browser) implementation of Argon2 by removing `BigInt` from the compression function's hot path. This resolves the long-standing `- Support for Argon2 in Node platform (TODO: requires optimization)` note in `CHANGELOG.md`.

## Problem

Argon2's hottest operation is the BLaMka G-function's 64-bit fused multiply-add, `z = x + y + 2 * (lo32(x) * lo32(y))`. On the VM this runs in native `Uint64List` arithmetic, but JS has no 64-bit integers, so the web twin `_fBlaMka` in `lib/src/algorithms/argon2/argon2_32bit.dart` implemented it with heap-allocating `BigInt`. `_fBlaMka` is called 4× per `_mix`, 8 `_mix` per mixer, 16 mixers per block, over thousands of blocks — so `BigInt` allocation and arbitrary-precision math sat on the single hottest line of the whole KDF.

## Change

Replace the `BigInt`-based `_fBlaMka` with pure 32-bit integer math:

- a full 32×32→64 low-word product built from 16-bit limbs, and
- carry-based addition of the `(low, high)` pairs,

with every intermediate kept below `2^53` so results stay exact on IEEE-754 doubles. This mirrors the `BigInt`-free pattern the sibling `blake2b_32bit.dart` already uses (`_add2`/`_add3` carry idiom). No public API, signature, or exported symbol changes — it is an internal swap behind the existing conditional import.

## Correctness

Output is byte-identical to the previous implementation. The Argon2 known-answer vectors (`test/argon2_test.dart`, sourced from argon2.online, argon2i/d/id at m=16 and m=256) are **not** vm-only, so they exercise the JS path directly — all pass, which is the proof a carry bug would break.

- `dart format --output=none --set-exit-if-changed .` — clean
- `dart analyze --fatal-infos` — zero infos
- `dart test -p vm` — 736 passed
- `dart test -p node` — 601 passed

## Performance

Measured on the compiled JS build under Node, `argon2id` at `Argon2Security.moderate`, averaged over 10 rounds:

| | ms/op |
| --- | --- |
| Before (`BigInt`) | 13,738.90 |
| After (32-bit math) | 882.80 |

≈ **15.6× faster** on the web platform. The VM path (`argon2_64bit.dart`) is unchanged.

## Notes

- Bumps `version` to `2.4.3` and adds the matching `CHANGELOG.md` entry.
- `BENCHMARK.md` is intentionally untouched (regenerated only on the maintainer's reference hardware).

🤖 _Generated by [Claude Code](https://claude.ai/code/session_017eisc4WSZNcgCUna825rS8)_